### PR TITLE
feat: add README badges and test coverage CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,30 @@
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up JDK 11
+      uses: actions/setup-java@v4
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: maven
+        
+    - name: Build with Maven
+      run: mvn -B verify --file pom.xml
+      
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        slug: intersoftdatalabs-in/ai-build-integrity-maven-plugin

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.intsof/ai-build-integrity-maven-plugin)](https://central.sonatype.com/artifact/com.intsof/ai-build-integrity-maven-plugin)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Build](https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/actions/workflows/maven.yml/badge.svg)](https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/actions/workflows/maven.yml)
+[![Test Coverage](https://img.shields.io/codecov/c/github/intersoftdatalabs-in/ai-build-integrity-maven-plugin)](https://codecov.io/gh/intersoftdatalabs-in/ai-build-integrity-maven-plugin)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/<PROJECT_ID>/badge)](https://www.bestpractices.dev/projects/<PROJECT_ID>)
 
 </div>
 

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,26 @@
                 <version>${maven.surefire.plugin.version}</version>
             </plugin>
             <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <phase>test</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
                 <version>${spotless.version}</version>


### PR DESCRIPTION
This PR adds a Build Badge, Test Coverage Badge, and an OpenSSF Best Practices Badge to the `README.md`. It also configures a GitHub Actions workflow to run Maven builds, gather JaCoCo coverage reports, and upload them to Codecov.