### PR TITLE
docs: add temp file rule and bump version to 0.10.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ buildNumber.properties
 .mvn/wrapper/maven-wrapper.jar
 *.log
 
+# AI generated temp files
+.tmp
+
 # IDE
 .idea/
 *.iml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,4 +13,5 @@
 - ANY time you modify code to address unexpected behavior or fix a bug, you MUST explicitly log each instance as a detailed bug issue in the GitHub repository. DO NOT make un-logged bug fixes.
 - When implementing new features or fixing bugs, create a feature branch and submit a pull request for review.
 - The project follows semantic versioning (https://semver.org/). When committing features or bug fixes, the version in pom.xml should be updated to reflect this (PATCH for bug fixes, MINOR for backwards-compatible features, MAJOR for breaking changes).
+- All temporary files should be written to the `.tmp` folder in the repository and removed when no longer needed.
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>com.intsof</groupId>
     <artifactId>ai-build-integrity-maven-plugin</artifactId>
-    <version>0.9.1-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>AI Build Integrity Maven Plugin</name>


### PR DESCRIPTION
## Summary
- Add rule to AGENTS.md: temporary files should be written to `.tmp` folder and removed when no longer needed
- Bump version from `0.9.1-SNAPSHOT` to `0.10.0-SNAPSHOT` for new feature release
- Add `.tmp` to `.gitignore`

## Changes
1. **AGENTS.md**: Added rule about temporary files in `.tmp` folder
2. **pom.xml**: Bumped version to `0.10.0-SNAPSHOT`
3. **.gitignore**: Added `.tmp` to ignore list

## Breaking Changes
None