### PR TITLE
docs: add temp file and changelog rules, update CHANGELOG for 0.10.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,4 +14,5 @@
 - When implementing new features or fixing bugs, create a feature branch and submit a pull request for review.
 - The project follows semantic versioning (https://semver.org/). When committing features or bug fixes, the version in pom.xml should be updated to reflect this (PATCH for bug fixes, MINOR for backwards-compatible features, MAJOR for breaking changes).
 - All temporary files should be written to the `.tmp` folder in the repository and removed when no longer needed.
+- When committing features or bug fixes, the CHANGELOG.md must be updated with the changes made in that version.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.10.0] - 2026-06-03
 
 ### Added
 
@@ -33,6 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - .gitignore awareness and automatic directory pruning.
 - Machine-readable JSON audit reports for SIEM integration.
 
-[Unreleased]: https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/compare/v0.9.0...HEAD
+[0.10.0]: https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/compare/v0.9.0...HEAD
 [0.9.0]: https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/releases/tag/v0.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Resume-Safe Hash Regeneration**: When resuming a failed multi-module build with `-rf :module-name`, the plugin now regenerates hashes only for the resuming module, allowing intentional edits made during the failed build to pass verification without triggering tamper detection.
 - **Javadoc & JaCoCo Reports**: Integrated API documentation and visual test coverage reports into the Maven site.
 - **Reference Documentation**: Added a formal specification for all plugin inputs (configuration) and outputs (ledger/audit reports).
 - **Maintenance Policy**: Formally documented the project's maintenance and update schedule in `CONTRIBUTING.md`.


### PR DESCRIPTION
## Summary
- Add AGENTS.md rule: temporary files should go in `.tmp` folder and be removed when done
- Add AGENTS.md rule: CHANGELOG.md must be updated when committing features or bug fixes
- Add `.tmp` to `.gitignore`
- Bump version to `0.10.0-SNAPSHOT`
- Update CHANGELOG.md with resume-safe hash regeneration feature

## Changes
1. **AGENTS.md**: Added two new rules:
   - Temp files go in `.tmp` folder and should be removed
   - CHANGELOG.md must be updated with each version change
2. **pom.xml**: Bumped version to `0.10.0-SNAPSHOT`
3. **.gitignore**: Added `.tmp`
4. **CHANGELOG.md**: Added entry for resume-safe hash regeneration feature

## Breaking Changes
None