### PR TITLE
feat: reactor-scoped hash generation for partial multi-module builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2026-07-10
+
+### Added
+
+- **Reactor-scoped hash generation**: On partial multi-module builds (`-pl`, child-module builds against a multi-module `baseDir`), `generate-hashes` walks only the selected module seal roots instead of rehashing the entire reactor tree. Full reactor builds still seal the full configured `baseDir`.
+- **`ai.integrity.reactorScope`**: `AUTO` (default), `FULL`, or `REACTOR` to control full-tree vs reactor-scoped sealing.
+- **CENTRAL ledger merge on partial seals**: Existing out-of-scope ledger entries are preserved; only paths under seal roots are refreshed.
+- Design mini-spec: `docs/superpowers/specs/2026-07-10-reactor-scoped-hash-generation-design.md`.
+
 ## [0.11.1] - 2026-07-01
 
 ### Fixed
@@ -60,6 +69,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - .gitignore awareness and automatic directory pruning.
 - Machine-readable JSON audit reports for SIEM integration.
 
-[0.10.0]: https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/compare/v0.9.0...HEAD
+[0.12.0]: https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/compare/v0.11.0...v0.11.1
+[0.11.0]: https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/compare/v0.10.0...v0.11.0
+[0.10.0]: https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/releases/tag/v0.9.0
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The plugin is available on Maven Central as of version 0.9.0.
 <plugin>
     <groupId>com.intsof</groupId>
     <artifactId>ai-build-integrity-maven-plugin</artifactId>
-    <version>0.11.1</version>
+    <version>0.12.0</version>
     <configuration>
         <!-- Centralized ledger: no sidecar files in your source tree -->
         <hashFileMode>CENTRAL</hashFileMode>
@@ -86,11 +86,12 @@ The plugin is available on Maven Central as of version 0.9.0.
 Maven has no lifecycle event that fires once when the entire reactor finishes. To catch mid-build
 tampering you must verify in **every module**. The correct architecture is:
 
-- `generate-hashes` — seals all files once at `VALIDATE` on the **root only**
+- `generate-hashes` — seals files at `VALIDATE` on the **root only** (full tree on full reactors; selected modules only on `-pl` / partial reactors, with CENTRAL ledger merge)
 - `verify-hashes` — re-verifies in **every module** at `TEST` before packaging
 - `clean-hashes` — deletes the ledger once on the **root only**
 
 `centralHashFile` is required to point all child modules at the single shared ledger the root writes.
+Use `-Dai.integrity.reactorScope=FULL` when you need a forced full-tree re-seal during a partial build.
 
 ```xml
 <build>
@@ -99,7 +100,7 @@ tampering you must verify in **every module**. The correct architecture is:
             <plugin>
                 <groupId>com.intsof</groupId>
                 <artifactId>ai-build-integrity-maven-plugin</artifactId>
-                <version>0.11.1</version>
+                <version>0.12.0</version>
                 <configuration>
                     <hashFileMode>CENTRAL</hashFileMode>
                     <!-- Scan the entire repo, not just the current module's basedir -->

--- a/docs/superpowers/specs/2026-07-10-reactor-scoped-hash-generation-design.md
+++ b/docs/superpowers/specs/2026-07-10-reactor-scoped-hash-generation-design.md
@@ -1,0 +1,144 @@
+# Reactor-Scoped Hash Generation (Mini Spec)
+
+**Date:** 2026-07-10  
+**Project:** ai-build-integrity-maven-plugin  
+**Status:** Approved for implementation  
+**Semver:** MINOR (backwards-compatible default improvement)
+
+## 1. Problem
+
+The recommended multi-module configuration is:
+
+|       Setting       |                 Value                  |
+|---------------------|----------------------------------------|
+| `baseDir`           | `${maven.multiModuleProjectDirectory}` |
+| `executionRootOnly` | `true` on `generate-hashes`            |
+| `hashFileMode`      | `CENTRAL`                              |
+
+`HashGeneratorMojo` always walks configured `baseDir` and, in CENTRAL mode, **overwrites** the ledger from that full scan. A partial build (e.g. `mvn -pl :module-62 package`, or building from a child module directory) therefore re-walks and rehashes the entire multi-module tree (e.g. 62 modules) before the selected module builds.
+
+Existing related features do **not** solve this:
+
+- `skipExisting` — SIDECAR only; does not apply to CENTRAL.
+- `resumeFromModule` / `-rf` — resume-only; does not handle `-pl` or child-directory builds.
+
+## 2. Goal
+
+**Default (option A — module-scoped seal):** seal only what the current Maven reactor is building.
+
+| Reactor |                                           Behavior                                            |
+|---------|-----------------------------------------------------------------------------------------------|
+| Full    | Walk configured `baseDir` once and rewrite the central ledger (unchanged).                    |
+| Partial | Walk only **seal roots** derived from `session.getProjects()`; merge into the central ledger. |
+
+No new required configuration for the common multi-module POM samples. Optional force-full escape hatch.
+
+## 3. Approach
+
+**Approach 1 — Walk seal roots from the current reactor** (chosen).
+
+Rejected alternatives:
+
+- Full walk + filter (still pays full tree walk).
+- Config-only per-module `baseDir` (breaks “seal once at root” model).
+
+## 4. Partial-reactor detection
+
+Treat the build as **partial** when any of the following hold:
+
+1. `session.getAllProjects()` is non-null/non-empty and  
+   `session.getProjects().size() < session.getAllProjects().size()`, or
+2. The request has an explicit non-empty `-pl` selection **and** the reactor is a proper subset of `getAllProjects()` when all-projects is available, or
+3. Configured `baseDir` is a strict **ancestor** of every selected project basedir, and no selected project’s basedir equals `baseDir` (typical `cd module-62 && mvn …` with multi-module `baseDir`).
+
+Otherwise treat as **full**.
+
+Log example:
+
+```text
+Partial reactor detected (1 of 62 projects); sealing 1 module root(s).
+```
+
+## 5. Seal roots
+
+From basedirs of `session.getProjects()` (absolute, normalized):
+
+- Include only basedirs that are equal to or under configured `baseDir`.
+- A basedir is a **seal root** if no *other* selected basedir is a proper child of it.
+
+Effects:
+
+- `-pl :module-62` → seal root = module-62 only.
+- `-pl :module-62 -am` including aggregator → seal roots = deepest selected modules only (aggregator basedir is **not** walked as a whole tree).
+- Full reactor → ignore seal-root reduction; walk configured `baseDir` (covers root-level files outside child modules).
+
+## 6. CENTRAL ledger merge
+
+Today generation overwrites the central file. A partial seal must not drop other modules’ entries.
+
+On **partial** generate:
+
+1. If the central ledger exists, load it.
+2. Drop entries whose relative path (resolved against `baseDir`) lies under any seal root.
+3. Append newly computed hashes for files found under seal roots (may be empty).
+4. Write the merged ledger.
+
+If no ledger exists, write a partial ledger (only sealed paths).
+
+On **full** generate: keep overwrite-from-full-scan (authoritative full seal).
+
+Even when no files match includes under seal roots, still perform merge step 2–4 so stale entries under those roots are removed.
+
+## 7. SIDECAR mode
+
+- Partial: create/update sidecars only under seal roots; leave other modules’ sidecars untouched.
+- Full: unchanged.
+
+## 8. Configuration
+
+|          Property           |   Type   | Default |                                                                Purpose                                                                 |
+|-----------------------------|----------|---------|----------------------------------------------------------------------------------------------------------------------------------------|
+| `ai.integrity.reactorScope` | `String` | `AUTO`  | `AUTO` = full vs partial as above; `FULL` = always walk `baseDir`; `REACTOR` = always use seal-root walks from `session.getProjects()` |
+
+Invalid values → fail the build with a clear error (or treat as AUTO with a warning; **prefer fail** for explicit misconfiguration).
+
+## 9. Verify / clean (non-goals for this change)
+
+|              Goal               |                                  Behavior                                  |
+|---------------------------------|----------------------------------------------------------------------------|
+| `verify-hashes` CENTRAL         | Unchanged (ledger-driven). May still verify preserved non-reactor entries. |
+| `verify-hashes` SIDECAR         | Optional follow-up: scope walk to seal roots.                              |
+| `clean-hashes`                  | Out of scope.                                                              |
+| Artifact digest mojos           | Out of scope.                                                              |
+| Reuse-if-present without rehash | Out of scope (option B).                                                   |
+
+## 10. Interaction with existing features
+
+- **`executionRootOnly`:** unchanged.
+- **`resumeFromModule` / `-rf`:** existing skip/regen rules remain; seal roots still apply when the reactor is partial.
+- **`skipExisting`:** SIDECAR only; orthogonal.
+
+## 11. Tests
+
+1. Full reactor + CENTRAL → full ledger rewrite (existing behavior).
+2. Partial reactor (subset of modules) → only seal-root paths hashed; other modules’ files not visited for hashing.
+3. Partial + existing full ledger → merge preserves other modules; refreshes selected paths.
+4. Partial + no ledger → partial ledger only.
+5. Aggregator + leaf selected (`-am` style) → seal root is leaf only.
+6. `reactorScope=FULL` forces full walk on an otherwise partial reactor.
+7. SIDECAR partial does not alter out-of-scope sidecars.
+8. Empty match under seal roots still drops stale CENTRAL entries under those roots.
+
+## 12. Documentation
+
+- `usage.md` / README multi-module section: document AUTO partial sealing.
+- `troubleshooting.md`: update `-pl` note.
+- `reference.md`: new property.
+- `CHANGELOG.md` + version bump (MINOR).
+
+## 13. Implementation notes
+
+- Prefer a small pure helper (e.g. `ReactorSealScope`) for detection, seal-root reduction, and ledger merge so unit tests do not require full Mojo wiring for every case.
+- Relative paths in the central ledger remain relative to configured `baseDir` (forward slashes).
+- Java 8 source/target compatibility required.
+

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>com.intsof</groupId>
     <artifactId>ai-build-integrity-maven-plugin</artifactId>
-    <version>0.11.1</version>
+    <version>0.12.0</version>
     <packaging>maven-plugin</packaging>
 
     <name>AI Build Integrity Maven Plugin</name>

--- a/src/main/java/com/intsof/ai/build/integrity/HashGeneratorMojo.java
+++ b/src/main/java/com/intsof/ai/build/integrity/HashGeneratorMojo.java
@@ -26,7 +26,9 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
@@ -156,6 +158,16 @@ public class HashGeneratorMojo extends AbstractMojo {
   @Parameter(property = "ai.integrity.centralHashFile")
   private String centralHashFile;
 
+  /**
+   * Controls whether hash generation walks the full configured {@code baseDir} or only modules in
+   * the current Maven reactor. {@code AUTO} (default) uses a full-tree seal for full reactor builds
+   * and seal-root walks for partial builds ({@code -pl}, child-module builds). {@code FULL} always
+   * walks {@code baseDir}. {@code REACTOR} always walks seal roots from {@code
+   * session.getProjects()}.
+   */
+  @Parameter(property = "ai.integrity.reactorScope", defaultValue = "AUTO")
+  private String reactorScope;
+
   @Override
   public void execute() throws MojoExecutionException {
     if (skip || skipAlt) {
@@ -188,15 +200,51 @@ public class HashGeneratorMojo extends AbstractMojo {
       getLog().info("Resume mode: regenerating hashes for " + resumeFromModule);
     }
 
+    final ReactorSealScope.Mode scopeMode;
+    try {
+      scopeMode = ReactorSealScope.parseMode(reactorScope);
+    } catch (IllegalArgumentException e) {
+      throw new MojoExecutionException(e.getMessage(), e);
+    }
+
     String algorithm = HashUtils.resolveAlgorithm(algorithmBits);
     String ext = resolveExtension();
 
-    Path basePath = resolveBasePath();
+    Path basePath = resolveBasePath().toAbsolutePath().normalize();
     getLog().info("Generating " + algorithm + " hashes for AI resources in: " + basePath);
 
     if (!Files.exists(basePath)) {
       getLog().warn("Base directory does not exist: " + basePath);
       return;
+    }
+
+    boolean partial = ReactorSealScope.isPartialReactor(session, basePath);
+    boolean mergeCentral = ReactorSealScope.shouldMergeCentral(scopeMode, partial);
+    List<Path> walkRoots = ReactorSealScope.resolveWalkRoots(basePath, session, scopeMode, partial);
+    List<Path> sealRootsForMerge =
+        mergeCentral ? ReactorSealScope.computeSealRoots(session, basePath) : walkRoots;
+
+    if (mergeCentral) {
+      int selected =
+          session != null && session.getProjects() != null ? session.getProjects().size() : 0;
+      int all =
+          session != null && session.getAllProjects() != null
+              ? session.getAllProjects().size()
+              : selected;
+      String label =
+          partial || scopeMode == ReactorSealScope.Mode.AUTO
+              ? "Partial reactor detected"
+              : "Reactor-scoped sealing";
+      getLog()
+          .info(
+              label
+                  + " ("
+                  + selected
+                  + " of "
+                  + all
+                  + " projects); walking "
+                  + walkRoots.size()
+                  + " seal root(s).");
     }
 
     Set<String> skipSet = parseSkipDirs();
@@ -208,40 +256,46 @@ public class HashGeneratorMojo extends AbstractMojo {
     List<Path> filesToHash = new ArrayList<>();
     final long[] scanned = {0};
     long walkStart = System.currentTimeMillis();
-    try {
-      Files.walkFileTree(
-          basePath,
-          new GitIgnoreAwareFileVisitor(
-              basePath, gitignoreAutoExclude, skipSet, forceIncludeMatchers, getLog()) {
-            @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-              scanned[0]++;
-              if (scanned[0] % 1000 == 0) {
-                getLog()
-                    .info(
-                        "  ... scanned "
-                            + scanned[0]
-                            + " files, "
-                            + filesToHash.size()
-                            + " matched so far");
-              }
-              Path rel = basePath.relativize(file);
-              boolean gitIgnored = isIgnoredByGit(file);
+    for (Path walkRoot : walkRoots) {
+      if (!Files.exists(walkRoot)) {
+        getLog().warn("Seal root does not exist, skipping: " + walkRoot);
+        continue;
+      }
+      try {
+        Files.walkFileTree(
+            walkRoot,
+            new GitIgnoreAwareFileVisitor(
+                basePath, gitignoreAutoExclude, skipSet, forceIncludeMatchers, getLog()) {
+              @Override
+              public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                scanned[0]++;
+                if (scanned[0] % 1000 == 0) {
+                  getLog()
+                      .info(
+                          "  ... scanned "
+                              + scanned[0]
+                              + " files, "
+                              + filesToHash.size()
+                              + " matched so far");
+                }
+                Path rel = basePath.relativize(file.toAbsolutePath().normalize());
+                boolean gitIgnored = isIgnoredByGit(file);
 
-              if (gitIgnored && !matchesAny(rel, forceIncludeMatchers)) {
+                if (gitIgnored && !matchesAny(rel, forceIncludeMatchers)) {
+                  return FileVisitResult.CONTINUE;
+                }
+                if (matchesAny(rel, excludeMatchers)) {
+                  return FileVisitResult.CONTINUE;
+                }
+                if (matchesAny(rel, includeMatchers) || matchesAny(rel, forceIncludeMatchers)) {
+                  filesToHash.add(file);
+                }
                 return FileVisitResult.CONTINUE;
               }
-              if (matchesAny(rel, excludeMatchers)) {
-                return FileVisitResult.CONTINUE;
-              }
-              if (matchesAny(rel, includeMatchers) || matchesAny(rel, forceIncludeMatchers)) {
-                filesToHash.add(file);
-              }
-              return FileVisitResult.CONTINUE;
-            }
-          });
-    } catch (IOException e) {
-      throw new MojoExecutionException("Error walking directory: " + basePath, e);
+            });
+      } catch (IOException e) {
+        throw new MojoExecutionException("Error walking directory: " + walkRoot, e);
+      }
     }
     long walkMs = System.currentTimeMillis() - walkStart;
     getLog()
@@ -254,12 +308,16 @@ public class HashGeneratorMojo extends AbstractMojo {
                 + walkMs
                 + " ms");
 
-    if (filesToHash.isEmpty()) {
+    if (filesToHash.isEmpty() && !mergeCentral) {
       getLog().info("No files found to hash.");
       return;
     }
 
-    getLog().info("Found " + filesToHash.size() + " files to hash.");
+    if (!filesToHash.isEmpty()) {
+      getLog().info("Found " + filesToHash.size() + " files to hash.");
+    } else {
+      getLog().info("No files found to hash under seal roots; refreshing central ledger scope.");
+    }
 
     int hashed = 0;
     int skipped = 0;
@@ -272,25 +330,50 @@ public class HashGeneratorMojo extends AbstractMojo {
               : Paths.get(buildDirectory, "ai-integrity" + ext);
       try {
         Files.createDirectories(centralFilePath.getParent());
-        StringBuilder sb = new StringBuilder();
+        Map<String, String> newEntries = new LinkedHashMap<>();
         for (Path file : filesToHash) {
           try {
             String hash = HashUtils.computeHash(file, algorithm, normalizeLineEndings);
-            // Use stable relative paths for the central ledger
-            String relPath = basePath.relativize(file).toString().replace('\\', '/');
-            sb.append(hash).append("  ").append(relPath).append("\n");
+            String relPath =
+                basePath
+                    .relativize(file.toAbsolutePath().normalize())
+                    .toString()
+                    .replace('\\', '/');
+            newEntries.put(relPath, hash);
             hashed++;
           } catch (Exception e) {
             getLog().error("Failed to hash " + file + ": " + e.getMessage());
           }
         }
-        Files.write(centralFilePath, sb.toString().getBytes(StandardCharsets.UTF_8));
-        getLog().info("Central hash file written: " + centralFilePath);
+
+        final String ledgerContent;
+        if (mergeCentral) {
+          List<Path> roots = sealRootsForMerge.isEmpty() ? walkRoots : sealRootsForMerge;
+          String existing = "";
+          if (Files.exists(centralFilePath)) {
+            existing = new String(Files.readAllBytes(centralFilePath), StandardCharsets.UTF_8);
+          }
+          ledgerContent =
+              ReactorSealScope.mergeCentralLedger(existing, basePath, roots, newEntries);
+          getLog().info("Central hash file merged (partial seal): " + centralFilePath);
+        } else {
+          StringBuilder sb = new StringBuilder();
+          for (Map.Entry<String, String> e : newEntries.entrySet()) {
+            sb.append(e.getValue()).append("  ").append(e.getKey()).append('\n');
+          }
+          ledgerContent = sb.toString();
+          getLog().info("Central hash file written: " + centralFilePath);
+        }
+        Files.write(centralFilePath, ledgerContent.getBytes(StandardCharsets.UTF_8));
       } catch (IOException e) {
         throw new MojoExecutionException(
             "Failed to write central hash file: " + centralFilePath, e);
       }
     } else {
+      if (filesToHash.isEmpty()) {
+        getLog().info("No files found to hash.");
+        return;
+      }
       for (Path file : filesToHash) {
         String name = file.getFileName().toString();
         String prefix = (hideHashFiles && !name.startsWith(".")) ? "." : "";

--- a/src/main/java/com/intsof/ai/build/integrity/ReactorSealScope.java
+++ b/src/main/java/com/intsof/ai/build/integrity/ReactorSealScope.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.ai.build.integrity;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Resolves which directories {@code generate-hashes} should walk for multi-module reactors, and
+ * merges partial CENTRAL ledgers without dropping entries outside the current seal roots.
+ *
+ * <p>Full reactor builds keep a single walk of configured {@code baseDir}. Partial reactors (e.g.
+ * {@code -pl}, child-module builds against a multi-module {@code baseDir}) walk only the deepest
+ * selected module basedirs ("seal roots").
+ */
+final class ReactorSealScope {
+
+  /** How aggressively to scope hash generation to the current reactor. */
+  enum Mode {
+    /** Detect partial vs full reactor automatically. */
+    AUTO,
+    /** Always walk configured {@code baseDir} (legacy full-tree seal). */
+    FULL,
+    /** Always walk seal roots derived from {@code session.getProjects()}. */
+    REACTOR
+  }
+
+  private ReactorSealScope() {}
+
+  /**
+   * Parses the {@code ai.integrity.reactorScope} configuration value.
+   *
+   * @param value raw configuration string (may be null)
+   * @return the resolved mode
+   * @throws IllegalArgumentException if the value is non-blank and not a known mode
+   */
+  static Mode parseMode(String value) {
+    if (value == null || value.trim().isEmpty()) {
+      return Mode.AUTO;
+    }
+    String normalized = value.trim().toUpperCase(Locale.ROOT);
+    try {
+      return Mode.valueOf(normalized);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Invalid ai.integrity.reactorScope '" + value + "'. Expected AUTO, FULL, or REACTOR.", e);
+    }
+  }
+
+  /**
+   * Detects whether the current Maven session is building a proper subset of a larger multi-module
+   * project (or a child module against an ancestor {@code baseDir}).
+   *
+   * @param session the Maven session (may be null)
+   * @param basePath configured scan base directory
+   * @return {@code true} when generation should use seal-root walks under {@link Mode#AUTO}
+   */
+  static boolean isPartialReactor(MavenSession session, Path basePath) {
+    if (session == null || basePath == null) {
+      return false;
+    }
+
+    List<MavenProject> projects = session.getProjects();
+    if (projects == null || projects.isEmpty()) {
+      return false;
+    }
+
+    List<MavenProject> allProjects = session.getAllProjects();
+    if (allProjects != null && !allProjects.isEmpty() && projects.size() < allProjects.size()) {
+      return true;
+    }
+
+    Path normalizedBase = basePath.toAbsolutePath().normalize();
+    boolean anyEqualsBase = false;
+    boolean anyStrictChild = false;
+    for (MavenProject p : projects) {
+      if (p == null || p.getBasedir() == null) {
+        continue;
+      }
+      Path bd = p.getBasedir().toPath().toAbsolutePath().normalize();
+      if (bd.equals(normalizedBase)) {
+        anyEqualsBase = true;
+      } else if (bd.startsWith(normalizedBase)) {
+        anyStrictChild = true;
+      }
+    }
+
+    // Child-directory or -pl-only builds against multi-module baseDir: no selected project owns
+    // the base directory itself, but at least one lives underneath it.
+    return !anyEqualsBase && anyStrictChild;
+  }
+
+  /**
+   * Resolves the directories to walk for file discovery.
+   *
+   * @param basePath configured base directory (ledger-relative root)
+   * @param session current Maven session
+   * @param mode reactor scope mode
+   * @param partial whether AUTO detection classified this build as partial
+   * @return one or more existing directories to walk; never empty if {@code basePath} exists
+   */
+  static List<Path> resolveWalkRoots(
+      Path basePath, MavenSession session, Mode mode, boolean partial) {
+    if (basePath == null) {
+      return Collections.emptyList();
+    }
+    if (mode == Mode.FULL || (mode == Mode.AUTO && !partial)) {
+      return Collections.singletonList(basePath.toAbsolutePath().normalize());
+    }
+    List<Path> sealRoots = computeSealRoots(session, basePath);
+    if (sealRoots.isEmpty()) {
+      return Collections.singletonList(basePath.toAbsolutePath().normalize());
+    }
+    return sealRoots;
+  }
+
+  /**
+   * Computes deepest selected project basedirs under {@code basePath} (seal roots).
+   *
+   * @param session current Maven session
+   * @param basePath configured base directory
+   * @return seal roots ordered by path string; empty if none could be resolved
+   */
+  static List<Path> computeSealRoots(MavenSession session, Path basePath) {
+    if (session == null || basePath == null) {
+      return Collections.emptyList();
+    }
+    List<MavenProject> projects = session.getProjects();
+    if (projects == null || projects.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    Path normalizedBase = basePath.toAbsolutePath().normalize();
+    List<Path> candidates = new ArrayList<>();
+    for (MavenProject p : projects) {
+      if (p == null || p.getBasedir() == null) {
+        continue;
+      }
+      Path bd = p.getBasedir().toPath().toAbsolutePath().normalize();
+      if (bd.equals(normalizedBase) || bd.startsWith(normalizedBase)) {
+        candidates.add(bd);
+      }
+    }
+    if (candidates.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    // A basedir is a seal root if no other selected basedir is a proper child of it.
+    List<Path> sealRoots = new ArrayList<>();
+    for (Path candidate : candidates) {
+      boolean hasSelectedChild = false;
+      for (Path other : candidates) {
+        if (!candidate.equals(other) && other.startsWith(candidate)) {
+          hasSelectedChild = true;
+          break;
+        }
+      }
+      if (!hasSelectedChild) {
+        sealRoots.add(candidate);
+      }
+    }
+
+    // Deduplicate while preserving order
+    Set<Path> unique = new LinkedHashSet<>(sealRoots);
+    return new ArrayList<>(unique);
+  }
+
+  /**
+   * Returns {@code true} if absolute {@code file} lies under any of the seal roots (inclusive).
+   *
+   * @param file absolute or relative file path
+   * @param sealRoots seal root directories
+   * @return whether the file is in scope for partial sealing
+   */
+  static boolean isUnderAnySealRoot(Path file, List<Path> sealRoots) {
+    if (file == null || sealRoots == null || sealRoots.isEmpty()) {
+      return false;
+    }
+    Path normalized = file.toAbsolutePath().normalize();
+    for (Path root : sealRoots) {
+      if (root == null) {
+        continue;
+      }
+      Path nr = root.toAbsolutePath().normalize();
+      if (normalized.equals(nr) || normalized.startsWith(nr)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Merges a partial seal into an existing CENTRAL ledger.
+   *
+   * <p>Entries whose relative path resolves under any seal root are removed, then {@code
+   * newEntries} (hash → relative path pairs are stored as path → hash) are appended.
+   *
+   * @param existingLedger full text of the existing ledger, or {@code null}/empty if none
+   * @param basePath ledger path root
+   * @param sealRoots directories being re-sealed
+   * @param newEntries map of relative path (forward slashes) to hex hash
+   * @return merged ledger text ending with a trailing newline when non-empty
+   */
+  static String mergeCentralLedger(
+      String existingLedger, Path basePath, List<Path> sealRoots, Map<String, String> newEntries) {
+    Map<String, String> merged = new LinkedHashMap<>();
+
+    if (existingLedger != null && !existingLedger.isEmpty()) {
+      String[] lines = existingLedger.split("\n", -1);
+      for (String line : lines) {
+        if (line == null || line.trim().isEmpty()) {
+          continue;
+        }
+        String[] parts = line.trim().split("\\s+", 2);
+        if (parts.length < 2) {
+          continue;
+        }
+        String hash = parts[0];
+        String relPath = parts[1].trim().replace('\\', '/');
+        Path abs = basePath.resolve(relPath).toAbsolutePath().normalize();
+        if (!isUnderAnySealRoot(abs, sealRoots)) {
+          merged.put(relPath, hash);
+        }
+      }
+    }
+
+    if (newEntries != null) {
+      for (Map.Entry<String, String> e : newEntries.entrySet()) {
+        if (e.getKey() == null || e.getValue() == null) {
+          continue;
+        }
+        String rel = e.getKey().replace('\\', '/');
+        merged.put(rel, e.getValue());
+      }
+    }
+
+    if (merged.isEmpty()) {
+      return "";
+    }
+    StringBuilder sb = new StringBuilder();
+    for (Map.Entry<String, String> e : merged.entrySet()) {
+      sb.append(e.getValue()).append("  ").append(e.getKey()).append('\n');
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Whether generation should use merge semantics for the CENTRAL ledger (partial seal).
+   *
+   * @param mode reactor scope mode
+   * @param partial AUTO partial detection result
+   * @return {@code true} when the central ledger should be merged rather than overwritten
+   */
+  static boolean shouldMergeCentral(Mode mode, boolean partial) {
+    if (mode == Mode.FULL) {
+      return false;
+    }
+    if (mode == Mode.REACTOR) {
+      return true;
+    }
+    return partial;
+  }
+}

--- a/src/site/markdown/reference.md
+++ b/src/site/markdown/reference.md
@@ -6,19 +6,20 @@ This document provides technical reference for the inputs (configuration) and ou
 
 All configuration parameters can be passed via the `<configuration>` block in your `pom.xml` or via System Properties (using the `-D` flag).
 
-|       Parameter        |   Type    |             Default             |                                  Description                                  |
-|------------------------|-----------|---------------------------------|-------------------------------------------------------------------------------|
-| `algorithmBits`        | `int`     | `256`                           | Strength of the cryptographic digest: `256`, `384`, or `512`.                 |
-| `hashFileMode`         | `enum`    | `SIDECAR`                       | `CENTRAL` for a single ledger, or `SIDECAR` for hidden files next to sources. |
-| `baseDir`              | `String`  | `${project.basedir}`            | Root directory to scan for files.                                             |
-| `includes`             | `String`  | `**/*.md`                       | Comma-separated list of glob patterns to include.                             |
-| `excludes`             | `String`  | (various)                       | Comma-separated list of glob patterns to exclude.                             |
-| `skipDirs`             | `String`  | `target,.git,node_modules,.tmp` | Directories to prune entirely from traversal.                                 |
-| `normalizeLineEndings` | `boolean` | `false`                         | If `true`, normalizes CRLF to LF in-memory before hashing.                    |
-| `failOnError`          | `boolean` | `true`                          | (Verify only) If `false`, build continues on validation failure.              |
-| `generateAuditReport`  | `boolean` | `true`                          | (Verify only) Generates the machine-readable JSON report.                     |
-| `executionRootOnly`    | `boolean` | `false`                         | If `true`, only executes on the root module of a build.                       |
-| `skip`                 | `boolean` | `false`                         | Bypasses all plugin logic.                                                    |
+|       Parameter        |   Type    |             Default             |                                                                                          Description                                                                                          |
+|------------------------|-----------|---------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `algorithmBits`        | `int`     | `256`                           | Strength of the cryptographic digest: `256`, `384`, or `512`.                                                                                                                                 |
+| `hashFileMode`         | `enum`    | `SIDECAR`                       | `CENTRAL` for a single ledger, or `SIDECAR` for hidden files next to sources.                                                                                                                 |
+| `baseDir`              | `String`  | `${project.basedir}`            | Root directory to scan for files.                                                                                                                                                             |
+| `includes`             | `String`  | `**/*.md`                       | Comma-separated list of glob patterns to include.                                                                                                                                             |
+| `excludes`             | `String`  | (various)                       | Comma-separated list of glob patterns to exclude.                                                                                                                                             |
+| `skipDirs`             | `String`  | `target,.git,node_modules,.tmp` | Directories to prune entirely from traversal.                                                                                                                                                 |
+| `normalizeLineEndings` | `boolean` | `false`                         | If `true`, normalizes CRLF to LF in-memory before hashing.                                                                                                                                    |
+| `failOnError`          | `boolean` | `true`                          | (Verify only) If `false`, build continues on validation failure.                                                                                                                              |
+| `generateAuditReport`  | `boolean` | `true`                          | (Verify only) Generates the machine-readable JSON report.                                                                                                                                     |
+| `executionRootOnly`    | `boolean` | `false`                         | If `true`, only executes on the root module of a build.                                                                                                                                       |
+| `reactorScope`         | `String`  | `AUTO`                          | (`generate-hashes`) `AUTO` seals full tree on full reactors and selected modules on partial builds; `FULL` always walks `baseDir`; `REACTOR` always uses seal roots from the current reactor. |
+| `skip`                 | `boolean` | `false`                         | Bypasses all plugin logic.                                                                                                                                                                    |
 
 ---
 

--- a/src/site/markdown/troubleshooting.md
+++ b/src/site/markdown/troubleshooting.md
@@ -49,4 +49,4 @@ The `verify-hashes` goal executed, but it couldn't find the `target/ai-integrity
 
 **How to fix it:**
 1. Did you forget to run `generate-hashes`? If building locally skipping the `initialize` phase, you may just need to generate the initial hashes.
-2. Are you using `-pl` to target a child module from the root directory? If the parent module never executed `generate-hashes`, the child module won't find the global ledger. This is expected local development behavior.
+2. Are you using `-pl` to target a child module from the root directory? If no central ledger exists yet, a partial reactor only seals the selected modules (default `reactorScope=AUTO`). Run a full reactor build once, or force a full seal with `-Dai.integrity.reactorScope=FULL`, so the shared ledger covers the whole tree. If the parent never ran `generate-hashes` at all, verify will warn that the ledger is missing.

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -14,7 +14,7 @@ For a standard Maven application, attaching the plugin is incredibly simple. It 
         <plugin>
             <groupId>com.intsof</groupId>
             <artifactId>ai-build-integrity-maven-plugin</artifactId>
-            <version>0.10.0</version>
+            <version>0.12.0</version>
             <configuration>
                 <hashFileMode>CENTRAL</hashFileMode>
                 <!-- Define your hashing intensity -->
@@ -66,6 +66,12 @@ The correct architecture is therefore:
 | `verify-hashes`   | **Every module**                     | `TEST` — re-verifies the sealed ledger just before each module is packaged |
 | `clean-hashes`    | Root only (`executionRootOnly=true`) | `CLEAN` — removes the ledger once                                          |
 
+**Partial reactors (`-pl`, child-module builds):** With the default `reactorScope=AUTO`,
+`generate-hashes` only walks the modules in the current Maven reactor (seal roots) and **merges**
+those paths into the existing central ledger. A full reactor build still walks the entire
+`baseDir` and rewrites the ledger. Force a full re-seal anytime with
+`-Dai.integrity.reactorScope=FULL`.
+
 Because `verify-hashes` must read the ledger from every child module, you must use `centralHashFile`
 to point all modules at the single shared ledger written by the root. Without it, each child module
 looks in its own `target/` directory, finds nothing, and silently skips.
@@ -79,7 +85,7 @@ Add the following to your **root parent POM's** `<build><pluginManagement>` and 
             <plugin>
                 <groupId>com.intsof</groupId>
                 <artifactId>ai-build-integrity-maven-plugin</artifactId>
-                <version>0.10.0</version>
+                <version>0.12.0</version>
                 <configuration>
                     <hashFileMode>CENTRAL</hashFileMode>
                     <!-- Scan the entire repo from the root, not from each module's basedir -->
@@ -214,7 +220,7 @@ Generate cryptographic digests for your build artifacts to ensure supply-chain i
         <plugin>
             <groupId>com.intsof</groupId>
             <artifactId>ai-build-integrity-maven-plugin</artifactId>
-            <version>0.10.0</version>
+            <version>0.12.0</version>
             <executions>
                 <execution>
                     <id>generate-artifacts</id>

--- a/src/test/java/com/intsof/ai/build/integrity/HashGeneratorMojoTest.java
+++ b/src/test/java/com/intsof/ai/build/integrity/HashGeneratorMojoTest.java
@@ -22,8 +22,11 @@ import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,8 +37,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 @DisplayName("HashGeneratorMojo")
 class HashGeneratorMojoTest {
 
@@ -59,6 +65,7 @@ class HashGeneratorMojoTest {
     setField(mojo, "outputExtension", "auto");
     setField(mojo, "skipExisting", false);
     setField(mojo, "skipDirs", "target,.git,node_modules,.tmp");
+    setField(mojo, "reactorScope", "AUTO");
   }
 
   @Nested
@@ -456,6 +463,129 @@ class HashGeneratorMojoTest {
           "ignored .md file should not be hashed");
       assertTrue(
           Files.exists(tempDir.resolve("forced.txt.sha256")), "forced .txt file should be hashed");
+    }
+  }
+
+  @Nested
+  @DisplayName("Reactor Scope Tests")
+  class ReactorScopeTests {
+
+    @Test
+    @DisplayName("partial reactor only hashes seal-root modules and merges CENTRAL ledger")
+    void partialReactorMergesCentralLedger() throws Exception {
+      Path moduleA = tempDir.resolve("module-a");
+      Path moduleB = tempDir.resolve("module-b");
+      Files.createDirectories(moduleA);
+      Files.createDirectories(moduleB);
+      Files.write(moduleA.resolve("AGENTS.md"), "a".getBytes(StandardCharsets.UTF_8));
+      Files.write(moduleB.resolve("AGENTS.md"), "b".getBytes(StandardCharsets.UTF_8));
+
+      Path central = tempDir.resolve("ai-integrity.sha256");
+      // Simulate a prior full seal
+      String priorHashA = HashUtils.computeHash(moduleA.resolve("AGENTS.md"), "SHA-256", false);
+      String priorHashB = HashUtils.computeHash(moduleB.resolve("AGENTS.md"), "SHA-256", false);
+      Files.write(
+          central,
+          (priorHashA + "  module-a/AGENTS.md\n" + priorHashB + "  module-b/AGENTS.md\n")
+              .getBytes(StandardCharsets.UTF_8));
+
+      // Change only module-b content so a rehash is observable
+      Files.write(moduleB.resolve("AGENTS.md"), "b-changed".getBytes(StandardCharsets.UTF_8));
+      String newHashB = HashUtils.computeHash(moduleB.resolve("AGENTS.md"), "SHA-256", false);
+
+      MavenProject projB = mock(MavenProject.class);
+      when(projB.getBasedir()).thenReturn(moduleB.toFile());
+      MavenProject projA = mock(MavenProject.class);
+      when(projA.getBasedir()).thenReturn(moduleA.toFile());
+      when(session.getProjects()).thenReturn(Collections.singletonList(projB));
+      when(session.getAllProjects()).thenReturn(Arrays.asList(projA, projB));
+
+      setField(mojo, "hashFileMode", HashFileMode.CENTRAL);
+      setField(mojo, "centralHashFile", central.toString());
+      setField(mojo, "reactorScope", "AUTO");
+      setField(mojo, "hideHashFiles", false);
+
+      mojo.execute();
+
+      String content = new String(Files.readAllBytes(central), StandardCharsets.UTF_8);
+      assertTrue(content.contains(priorHashA + "  module-a/AGENTS.md"), "module-a preserved");
+      assertTrue(content.contains(newHashB + "  module-b/AGENTS.md"), "module-b refreshed");
+      assertFalse(content.contains(priorHashB + "  module-b/AGENTS.md"), "old module-b removed");
+      assertFalse(Files.exists(moduleA.resolve("AGENTS.md.sha256")), "should not create sidecars");
+    }
+
+    @Test
+    @DisplayName("reactorScope=FULL forces full-tree overwrite on partial reactor")
+    void fullScopeForcesFullTree() throws Exception {
+      Path moduleA = tempDir.resolve("module-a");
+      Path moduleB = tempDir.resolve("module-b");
+      Files.createDirectories(moduleA);
+      Files.createDirectories(moduleB);
+      Files.write(moduleA.resolve("AGENTS.md"), "a".getBytes(StandardCharsets.UTF_8));
+      Files.write(moduleB.resolve("AGENTS.md"), "b".getBytes(StandardCharsets.UTF_8));
+
+      Path central = tempDir.resolve("ai-integrity.sha256");
+      Files.write(central, "stale  module-a/AGENTS.md\n".getBytes(StandardCharsets.UTF_8));
+
+      MavenProject projB = mock(MavenProject.class);
+      when(projB.getBasedir()).thenReturn(moduleB.toFile());
+      MavenProject projA = mock(MavenProject.class);
+      when(projA.getBasedir()).thenReturn(moduleA.toFile());
+      when(session.getProjects()).thenReturn(Collections.singletonList(projB));
+      when(session.getAllProjects()).thenReturn(Arrays.asList(projA, projB));
+
+      setField(mojo, "hashFileMode", HashFileMode.CENTRAL);
+      setField(mojo, "centralHashFile", central.toString());
+      setField(mojo, "reactorScope", "FULL");
+
+      mojo.execute();
+
+      String content = new String(Files.readAllBytes(central), StandardCharsets.UTF_8);
+      assertTrue(content.contains("module-a/AGENTS.md"));
+      assertTrue(content.contains("module-b/AGENTS.md"));
+      assertFalse(content.contains("stale  "));
+    }
+
+    @Test
+    @DisplayName("SIDECAR partial only writes sidecars under seal roots")
+    void sidecarPartialOnlySealRoots() throws Exception {
+      Path moduleA = tempDir.resolve("module-a");
+      Path moduleB = tempDir.resolve("module-b");
+      Files.createDirectories(moduleA);
+      Files.createDirectories(moduleB);
+      Files.write(moduleA.resolve("AGENTS.md"), "a".getBytes(StandardCharsets.UTF_8));
+      Files.write(moduleB.resolve("AGENTS.md"), "b".getBytes(StandardCharsets.UTF_8));
+      // Pre-existing sidecar outside seal root must remain untouched
+      Files.write(
+          moduleA.resolve("AGENTS.md.sha256"),
+          "oldhash  AGENTS.md\n".getBytes(StandardCharsets.UTF_8));
+
+      MavenProject projB = mock(MavenProject.class);
+      when(projB.getBasedir()).thenReturn(moduleB.toFile());
+      MavenProject projA = mock(MavenProject.class);
+      when(projA.getBasedir()).thenReturn(moduleA.toFile());
+      when(session.getProjects()).thenReturn(Collections.singletonList(projB));
+      when(session.getAllProjects()).thenReturn(Arrays.asList(projA, projB));
+
+      setField(mojo, "hashFileMode", HashFileMode.SIDECAR);
+      setField(mojo, "hideHashFiles", false);
+      setField(mojo, "reactorScope", "AUTO");
+
+      mojo.execute();
+
+      assertTrue(Files.exists(moduleB.resolve("AGENTS.md.sha256")));
+      String aSidecar =
+          new String(
+              Files.readAllBytes(moduleA.resolve("AGENTS.md.sha256")), StandardCharsets.UTF_8);
+      assertEquals("oldhash  AGENTS.md\n", aSidecar);
+    }
+
+    @Test
+    @DisplayName("invalid reactorScope fails the build")
+    void invalidReactorScopeFails() throws Exception {
+      setField(mojo, "reactorScope", "SOMETIMES");
+      Files.write(tempDir.resolve("AGENTS.md"), "x".getBytes(StandardCharsets.UTF_8));
+      assertThrows(MojoExecutionException.class, () -> mojo.execute());
     }
   }
 

--- a/src/test/java/com/intsof/ai/build/integrity/ReactorSealScopeTest.java
+++ b/src/test/java/com/intsof/ai/build/integrity/ReactorSealScopeTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.ai.build.integrity;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ReactorSealScope")
+class ReactorSealScopeTest {
+
+  @Mock private MavenSession session;
+  @TempDir Path tempDir;
+
+  @Nested
+  @DisplayName("parseMode")
+  class ParseModeTests {
+
+    @Test
+    @DisplayName("defaults blank to AUTO")
+    void defaultsBlankToAuto() {
+      assertEquals(ReactorSealScope.Mode.AUTO, ReactorSealScope.parseMode(null));
+      assertEquals(ReactorSealScope.Mode.AUTO, ReactorSealScope.parseMode("  "));
+    }
+
+    @Test
+    @DisplayName("parses known modes case-insensitively")
+    void parsesKnownModes() {
+      assertEquals(ReactorSealScope.Mode.FULL, ReactorSealScope.parseMode("full"));
+      assertEquals(ReactorSealScope.Mode.REACTOR, ReactorSealScope.parseMode("Reactor"));
+      assertEquals(ReactorSealScope.Mode.AUTO, ReactorSealScope.parseMode("AUTO"));
+    }
+
+    @Test
+    @DisplayName("rejects unknown modes")
+    void rejectsUnknown() {
+      assertThrows(IllegalArgumentException.class, () -> ReactorSealScope.parseMode("maybe"));
+    }
+  }
+
+  @Nested
+  @DisplayName("isPartialReactor")
+  class IsPartialReactorTests {
+
+    @Test
+    @DisplayName("false when session is null")
+    void falseWhenSessionNull() {
+      assertFalse(ReactorSealScope.isPartialReactor(null, tempDir));
+    }
+
+    @Test
+    @DisplayName("true when projects is proper subset of allProjects")
+    void trueWhenSubsetOfAllProjects() {
+      MavenProject a = projectAt(tempDir.resolve("a"));
+      MavenProject b = projectAt(tempDir.resolve("b"));
+      when(session.getProjects()).thenReturn(Collections.singletonList(a));
+      when(session.getAllProjects()).thenReturn(Arrays.asList(a, b));
+
+      assertTrue(ReactorSealScope.isPartialReactor(session, tempDir));
+    }
+
+    @Test
+    @DisplayName("false when full reactor (projects equals allProjects)")
+    void falseWhenFullReactor() {
+      MavenProject root = projectAt(tempDir);
+      MavenProject a = projectAt(tempDir.resolve("a"));
+      when(session.getProjects()).thenReturn(Arrays.asList(root, a));
+      when(session.getAllProjects()).thenReturn(Arrays.asList(root, a));
+
+      assertFalse(ReactorSealScope.isPartialReactor(session, tempDir));
+    }
+
+    @Test
+    @DisplayName("true when only child modules selected against multi-module baseDir")
+    void trueWhenChildOnlyAgainstAncestorBaseDir() {
+      MavenProject child = projectAt(tempDir.resolve("module-62"));
+      when(session.getProjects()).thenReturn(Collections.singletonList(child));
+      when(session.getAllProjects()).thenReturn(Collections.singletonList(child));
+
+      assertTrue(ReactorSealScope.isPartialReactor(session, tempDir));
+    }
+  }
+
+  @Nested
+  @DisplayName("computeSealRoots")
+  class ComputeSealRootsTests {
+
+    @Test
+    @DisplayName("prefers deepest selected basedirs when aggregator is also selected")
+    void prefersDeepestBasedirs() {
+      MavenProject root = projectAt(tempDir);
+      MavenProject leaf = projectAt(tempDir.resolve("module-62"));
+      when(session.getProjects()).thenReturn(Arrays.asList(root, leaf));
+
+      List<Path> roots = ReactorSealScope.computeSealRoots(session, tempDir);
+      assertEquals(1, roots.size());
+      assertEquals(tempDir.resolve("module-62").toAbsolutePath().normalize(), roots.get(0));
+    }
+
+    @Test
+    @DisplayName("returns multiple sibling seal roots")
+    void returnsSiblingRoots() {
+      MavenProject a = projectAt(tempDir.resolve("a"));
+      MavenProject b = projectAt(tempDir.resolve("b"));
+      when(session.getProjects()).thenReturn(Arrays.asList(a, b));
+
+      List<Path> roots = ReactorSealScope.computeSealRoots(session, tempDir);
+      assertEquals(2, roots.size());
+      assertTrue(roots.contains(tempDir.resolve("a").toAbsolutePath().normalize()));
+      assertTrue(roots.contains(tempDir.resolve("b").toAbsolutePath().normalize()));
+    }
+  }
+
+  @Nested
+  @DisplayName("resolveWalkRoots")
+  class ResolveWalkRootsTests {
+
+    @Test
+    @DisplayName("AUTO full uses baseDir only")
+    void autoFullUsesBaseDir() {
+      MavenProject root = projectAt(tempDir);
+      when(session.getProjects()).thenReturn(Collections.singletonList(root));
+
+      List<Path> roots =
+          ReactorSealScope.resolveWalkRoots(tempDir, session, ReactorSealScope.Mode.AUTO, false);
+      assertEquals(Collections.singletonList(tempDir.toAbsolutePath().normalize()), roots);
+    }
+
+    @Test
+    @DisplayName("AUTO partial uses seal roots")
+    void autoPartialUsesSealRoots() {
+      MavenProject leaf = projectAt(tempDir.resolve("m"));
+      when(session.getProjects()).thenReturn(Collections.singletonList(leaf));
+
+      List<Path> roots =
+          ReactorSealScope.resolveWalkRoots(tempDir, session, ReactorSealScope.Mode.AUTO, true);
+      assertEquals(
+          Collections.singletonList(tempDir.resolve("m").toAbsolutePath().normalize()), roots);
+    }
+
+    @Test
+    @DisplayName("FULL forces baseDir even when partial")
+    void fullForcesBaseDir() {
+      MavenProject leaf = projectAt(tempDir.resolve("m"));
+      when(session.getProjects()).thenReturn(Collections.singletonList(leaf));
+
+      List<Path> roots =
+          ReactorSealScope.resolveWalkRoots(tempDir, session, ReactorSealScope.Mode.FULL, true);
+      assertEquals(Collections.singletonList(tempDir.toAbsolutePath().normalize()), roots);
+    }
+  }
+
+  @Nested
+  @DisplayName("mergeCentralLedger")
+  class MergeCentralLedgerTests {
+
+    @Test
+    @DisplayName("preserves out-of-scope entries and refreshes seal roots")
+    void preservesAndRefreshes() {
+      Path seal = tempDir.resolve("m62").toAbsolutePath().normalize();
+      String existing =
+          "aaa  other/module/AGENTS.md\n" + "bbb  m62/AGENTS.md\n" + "ccc  m62/nested/SKILL.md\n";
+
+      Map<String, String> neu = new LinkedHashMap<>();
+      neu.put("m62/AGENTS.md", "NEWHASH");
+
+      String merged =
+          ReactorSealScope.mergeCentralLedger(
+              existing, tempDir, Collections.singletonList(seal), neu);
+
+      assertTrue(merged.contains("aaa  other/module/AGENTS.md"));
+      assertTrue(merged.contains("NEWHASH  m62/AGENTS.md"));
+      assertFalse(merged.contains("bbb  m62/AGENTS.md"));
+      assertFalse(merged.contains("ccc  m62/nested/SKILL.md"));
+    }
+
+    @Test
+    @DisplayName("empty new entries still drops seal-root paths")
+    void emptyNewEntriesDropsScope() {
+      Path seal = tempDir.resolve("m62").toAbsolutePath().normalize();
+      String existing = "aaa  other/x.md\nbbb  m62/y.md\n";
+      String merged =
+          ReactorSealScope.mergeCentralLedger(
+              existing, tempDir, Collections.singletonList(seal), Collections.emptyMap());
+      assertEquals("aaa  other/x.md\n", merged);
+    }
+  }
+
+  @Nested
+  @DisplayName("shouldMergeCentral")
+  class ShouldMergeCentralTests {
+
+    @Test
+    @DisplayName("FULL never merges")
+    void fullNeverMerges() {
+      assertFalse(ReactorSealScope.shouldMergeCentral(ReactorSealScope.Mode.FULL, true));
+    }
+
+    @Test
+    @DisplayName("REACTOR always merges")
+    void reactorAlwaysMerges() {
+      assertTrue(ReactorSealScope.shouldMergeCentral(ReactorSealScope.Mode.REACTOR, false));
+    }
+
+    @Test
+    @DisplayName("AUTO merges only when partial")
+    void autoMergesWhenPartial() {
+      assertTrue(ReactorSealScope.shouldMergeCentral(ReactorSealScope.Mode.AUTO, true));
+      assertFalse(ReactorSealScope.shouldMergeCentral(ReactorSealScope.Mode.AUTO, false));
+    }
+  }
+
+  private static MavenProject projectAt(Path basedir) {
+    MavenProject p = mock(MavenProject.class);
+    when(p.getBasedir()).thenReturn(basedir.toFile());
+    return p;
+  }
+}


### PR DESCRIPTION
## Summary

- On partial multi-module builds (`-pl`, child-module builds against a multi-module `baseDir`), `generate-hashes` walks only the selected module **seal roots** instead of rehashing the entire reactor tree (e.g. all 62 modules when building module 62).
- Full reactor builds keep the existing full-`baseDir` seal behavior.
- CENTRAL mode **merges** partial seals into the existing ledger so other modules’ entries are preserved.
- New config: `ai.integrity.reactorScope` = `AUTO` (default) | `FULL` | `REACTOR`.
- Mini-spec: `docs/superpowers/specs/2026-07-10-reactor-scoped-hash-generation-design.md`
- Version bump to **0.12.0** (MINOR).

## Test plan

- [x] `mvn test` (full suite green locally)
- [x] Unit tests for `ReactorSealScope` (detection, seal roots, merge, modes)
- [x] `HashGeneratorMojo` tests: partial merge, `FULL` force, SIDECAR partial, invalid scope
- [ ] Manual: large multi-module project with `mvn -pl :last-module package` — confirm log shows partial reactor sealing and only that module tree is walked
- [ ] Manual: full reactor still produces a complete central ledger