### PR TITLE
feat: print recovery advice when integrity verification fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2026-07-16
+
+### Added
+
+- **Actionable recovery advice on verification failure**: When `verify-hashes` (or `verify-artifact-digests`) fails, the build log now prints intentional-change guidance: re-seal with `mvn validate` (hashes) or `mvn package` (artifact digests), plus the exact skip properties `-Dai.integrity.skip=true` / `-Dskip.ai.integrity=true`. The build still fails when `failOnError=true` (#42).
+
 ## [0.12.0] - 2026-07-10
 
 ### Added
@@ -69,7 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - .gitignore awareness and automatic directory pruning.
 - Machine-readable JSON audit reports for SIEM integration.
 
-[0.12.0]: https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/compare/v0.11.1...HEAD
+[0.13.0]: https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/compare/v0.9.0...v0.10.0

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The plugin is available on Maven Central as of version 0.9.0.
 <plugin>
     <groupId>com.intsof</groupId>
     <artifactId>ai-build-integrity-maven-plugin</artifactId>
-    <version>0.12.0</version>
+    <version>0.13.0</version>
     <configuration>
         <!-- Centralized ledger: no sidecar files in your source tree -->
         <hashFileMode>CENTRAL</hashFileMode>
@@ -100,7 +100,7 @@ Use `-Dai.integrity.reactorScope=FULL` when you need a forced full-tree re-seal 
             <plugin>
                 <groupId>com.intsof</groupId>
                 <artifactId>ai-build-integrity-maven-plugin</artifactId>
-                <version>0.12.0</version>
+                <version>0.13.0</version>
                 <configuration>
                     <hashFileMode>CENTRAL</hashFileMode>
                     <!-- Scan the entire repo, not just the current module's basedir -->

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>com.intsof</groupId>
     <artifactId>ai-build-integrity-maven-plugin</artifactId>
-    <version>0.12.0</version>
+    <version>0.13.0</version>
     <packaging>maven-plugin</packaging>
 
     <name>AI Build Integrity Maven Plugin</name>

--- a/src/main/java/com/intsof/ai/build/integrity/ArtifactDigestsVerifyMojo.java
+++ b/src/main/java/com/intsof/ai/build/integrity/ArtifactDigestsVerifyMojo.java
@@ -228,6 +228,7 @@ public class ArtifactDigestsVerifyMojo extends AbstractMojo {
     if (failed > 0 || missing > 0) {
       String msg =
           "Artifact digest verification FAILED: " + failed + " failed, " + missing + " missing.";
+      IntegrityFailureAdvice.logArtifactDigestVerificationRecovery(log);
       if (failOnError) {
         throw new MojoExecutionException(msg);
       } else {

--- a/src/main/java/com/intsof/ai/build/integrity/HashVerifyMojo.java
+++ b/src/main/java/com/intsof/ai/build/integrity/HashVerifyMojo.java
@@ -474,6 +474,7 @@ public class HashVerifyMojo extends AbstractMojo {
     if (failed > 0) {
       String msg =
           "Hash verification FAILED: " + failed + " file(s) have been modified or tampered with!";
+      IntegrityFailureAdvice.logHashVerificationRecovery(getLog());
       if (failOnError) {
         throw new MojoExecutionException(msg);
       } else {

--- a/src/main/java/com/intsof/ai/build/integrity/IntegrityFailureAdvice.java
+++ b/src/main/java/com/intsof/ai/build/integrity/IntegrityFailureAdvice.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.ai.build.integrity;
+
+import org.apache.maven.plugin.logging.Log;
+
+/**
+ * Formats and logs actionable recovery guidance when integrity verification fails.
+ *
+ * <p>Verification still fails the build when {@code failOnError} is true; this class only improves
+ * the developer-facing failure UX so intentional edits are easy to re-seal or temporarily skip.
+ */
+public final class IntegrityFailureAdvice {
+
+  /** Primary skip system property documented for end users. */
+  public static final String SKIP_PROPERTY = "ai.integrity.skip";
+
+  /** Alternate Maven-conventional skip system property. */
+  public static final String SKIP_PROPERTY_ALT = "skip.ai.integrity";
+
+  private static final String BANNER =
+      "------------------------------------------------------------------------";
+
+  private IntegrityFailureAdvice() {}
+
+  /**
+   * Logs recovery advice for AI resource hash verification failures ({@code verify-hashes}).
+   *
+   * @param log the Maven plugin logger; no-op when {@code null}
+   */
+  public static void logHashVerificationRecovery(Log log) {
+    logRecovery(
+        log,
+        "If these changes were intentional, re-seal the project by regenerating hashes:",
+        "  mvn validate",
+        "To temporarily skip integrity verification for this build:");
+  }
+
+  /**
+   * Logs recovery advice for artifact digest verification failures ({@code
+   * verify-artifact-digests}).
+   *
+   * @param log the Maven plugin logger; no-op when {@code null}
+   */
+  public static void logArtifactDigestVerificationRecovery(Log log) {
+    logRecovery(
+        log,
+        "If these changes were intentional, re-generate artifact digests (e.g. re-run packaging):",
+        "  mvn package",
+        "To temporarily skip integrity verification for this build:");
+  }
+
+  /**
+   * Shared multi-line recovery footer. Skip flags are identical for all integrity goals.
+   *
+   * @param log the Maven plugin logger
+   * @param intentionalLead lead sentence for intentional edits
+   * @param regenerateCommand example Maven command to re-seal (already indented)
+   * @param skipLead lead sentence before skip properties
+   */
+  static void logRecovery(
+      Log log, String intentionalLead, String regenerateCommand, String skipLead) {
+    if (log == null) {
+      return;
+    }
+    log.error(BANNER);
+    log.error(intentionalLead);
+    log.error(regenerateCommand);
+    log.error("");
+    log.error(skipLead);
+    log.error("  -D" + SKIP_PROPERTY + "=true");
+    log.error("  (also accepted: -D" + SKIP_PROPERTY_ALT + "=true)");
+    log.error(BANNER);
+  }
+}

--- a/src/main/java/com/intsof/ai/build/integrity/IntegrityFailureAdvice.java
+++ b/src/main/java/com/intsof/ai/build/integrity/IntegrityFailureAdvice.java
@@ -34,6 +34,12 @@ public final class IntegrityFailureAdvice {
   private static final String BANNER =
       "------------------------------------------------------------------------";
 
+  /**
+   * Non-empty spacer between advice blocks. Empty {@code log.error("")} lines are dropped by some
+   * Maven / SLF4J backends and CI shippers, which collapses the intended visual gap.
+   */
+  private static final String SPACER = " ";
+
   private IntegrityFailureAdvice() {}
 
   /**
@@ -79,7 +85,7 @@ public final class IntegrityFailureAdvice {
     log.error(BANNER);
     log.error(intentionalLead);
     log.error(regenerateCommand);
-    log.error("");
+    log.error(SPACER);
     log.error(skipLead);
     log.error("  -D" + SKIP_PROPERTY + "=true");
     log.error("  (also accepted: -D" + SKIP_PROPERTY_ALT + "=true)");

--- a/src/site/markdown/troubleshooting.md
+++ b/src/site/markdown/troubleshooting.md
@@ -20,6 +20,14 @@ If you intentionally modified the file (e.g., updating a system prompt in `AGENT
 mvn validate
 ```
 
+The build log prints the same recovery guidance on failure, including the exact skip properties for a temporary local bypass:
+
+```bash
+mvn <your-goals> -Dai.integrity.skip=true
+# also accepted:
+mvn <your-goals> -Dskip.ai.integrity=true
+```
+
 2. **Did a formatting tool rewrite the file?**
    If a plugin like `spotless:apply` rewrote the Markdown layout, injected a license header, or altered line-endings mid-build, the hash will change and verification will fail. Ensure your formatters are configured to run *before* `generate-hashes` in the Maven lifecycle (see [Usage](./usage.html)).
 

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -14,7 +14,7 @@ For a standard Maven application, attaching the plugin is incredibly simple. It 
         <plugin>
             <groupId>com.intsof</groupId>
             <artifactId>ai-build-integrity-maven-plugin</artifactId>
-            <version>0.12.0</version>
+            <version>0.13.0</version>
             <configuration>
                 <hashFileMode>CENTRAL</hashFileMode>
                 <!-- Define your hashing intensity -->
@@ -85,7 +85,7 @@ Add the following to your **root parent POM's** `<build><pluginManagement>` and 
             <plugin>
                 <groupId>com.intsof</groupId>
                 <artifactId>ai-build-integrity-maven-plugin</artifactId>
-                <version>0.12.0</version>
+                <version>0.13.0</version>
                 <configuration>
                     <hashFileMode>CENTRAL</hashFileMode>
                     <!-- Scan the entire repo from the root, not from each module's basedir -->
@@ -220,7 +220,7 @@ Generate cryptographic digests for your build artifacts to ensure supply-chain i
         <plugin>
             <groupId>com.intsof</groupId>
             <artifactId>ai-build-integrity-maven-plugin</artifactId>
-            <version>0.12.0</version>
+            <version>0.13.0</version>
             <executions>
                 <execution>
                     <id>generate-artifacts</id>

--- a/src/test/java/com/intsof/ai/build/integrity/ArtifactDigestsVerifyMojoTest.java
+++ b/src/test/java/com/intsof/ai/build/integrity/ArtifactDigestsVerifyMojoTest.java
@@ -16,6 +16,7 @@
 package com.intsof.ai.build.integrity;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Field;
@@ -23,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -38,6 +40,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ArtifactDigestsVerifyMojoTest {
 
   @Mock private MavenProject project;
+  @Mock private Log log;
   @TempDir Path tempDir;
 
   private ArtifactDigestsVerifyMojo mojo;
@@ -45,7 +48,7 @@ class ArtifactDigestsVerifyMojoTest {
   @BeforeEach
   void setUp() throws Exception {
     mojo = new ArtifactDigestsVerifyMojo();
-    mojo.setLog(new org.apache.maven.plugin.logging.SystemStreamLog());
+    mojo.setLog(log);
     setField(mojo, "project", project);
     setField(mojo, "buildDirectory", tempDir.toString());
     setField(mojo, "algorithms", new String[] {"SHA-256"});
@@ -87,8 +90,11 @@ class ArtifactDigestsVerifyMojoTest {
       // Tamper with the artifact
       Files.write(jarFile, "tampered content".getBytes(StandardCharsets.UTF_8));
 
-      // When/Then - should throw
+      // When/Then - should throw and log recovery advice
       assertThrows(MojoExecutionException.class, () -> mojo.execute());
+      verify(log).error(contains("If these changes were intentional"));
+      verify(log).error(contains("mvn package"));
+      verify(log).error(contains("-Dai.integrity.skip=true"));
     }
 
     @Test

--- a/src/test/java/com/intsof/ai/build/integrity/HashVerifyMojoTest.java
+++ b/src/test/java/com/intsof/ai/build/integrity/HashVerifyMojoTest.java
@@ -94,6 +94,12 @@ class HashVerifyMojoTest {
       MojoExecutionException ex = assertThrows(MojoExecutionException.class, () -> mojo.execute());
       assertTrue(ex.getMessage().contains("FAILED"));
       assertTrue(ex.getMessage().contains("tampered"));
+      // Exception message stays short; recovery guidance is logged separately
+      assertFalse(ex.getMessage().contains("mvn validate"));
+      verify(log).error(contains("If these changes were intentional"));
+      verify(log).error(contains("mvn validate"));
+      verify(log).error(contains("-Dai.integrity.skip=true"));
+      verify(log).error(contains("-Dskip.ai.integrity=true"));
     }
 
     @Test
@@ -107,6 +113,26 @@ class HashVerifyMojoTest {
       // When/Then
       MojoExecutionException ex = assertThrows(MojoExecutionException.class, () -> mojo.execute());
       assertTrue(ex.getMessage().contains("FAILED"));
+      verify(log).error(contains("If these changes were intentional"));
+      verify(log).error(contains("mvn validate"));
+    }
+
+    @Test
+    @DisplayName("should log recovery advice when failOnError is false")
+    void shouldLogRecoveryAdviceWhenFailOnErrorFalse() throws Exception {
+      setField(mojo, "failOnError", false);
+      Files.write(
+          tempDir.resolve("AGENTS.md"), "# AI Agent Instructions".getBytes(StandardCharsets.UTF_8));
+      Files.write(
+          tempDir.resolve("AGENTS.md.sha256"),
+          "0000000000000000000000000000000000000000000000000000000000000000  AGENTS.md\n"
+              .getBytes(StandardCharsets.UTF_8));
+
+      assertDoesNotThrow(() -> mojo.execute());
+      verify(log).error(contains("If these changes were intentional"));
+      verify(log).error(contains("mvn validate"));
+      verify(log).error(contains("-Dai.integrity.skip=true"));
+      verify(log).error(contains("AI BUILD INTEGRITY WARNING"));
     }
 
     @Test

--- a/src/test/java/com/intsof/ai/build/integrity/IntegrityFailureAdviceTest.java
+++ b/src/test/java/com/intsof/ai/build/integrity/IntegrityFailureAdviceTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.ai.build.integrity;
+
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.apache.maven.plugin.logging.Log;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("IntegrityFailureAdvice")
+class IntegrityFailureAdviceTest {
+
+  @Test
+  @DisplayName("logHashVerificationRecovery should advise mvn validate and skip -D options")
+  void logHashVerificationRecoveryEmitsExpectedGuidance() {
+    Log log = mock(Log.class);
+
+    IntegrityFailureAdvice.logHashVerificationRecovery(log);
+
+    verify(log).error(contains("If these changes were intentional"));
+    verify(log).error(contains("mvn validate"));
+    verify(log).error(contains("-D" + IntegrityFailureAdvice.SKIP_PROPERTY + "=true"));
+    verify(log).error(contains("-D" + IntegrityFailureAdvice.SKIP_PROPERTY_ALT + "=true"));
+  }
+
+  @Test
+  @DisplayName(
+      "logArtifactDigestVerificationRecovery should advise mvn package and skip -D options")
+  void logArtifactDigestVerificationRecoveryEmitsExpectedGuidance() {
+    Log log = mock(Log.class);
+
+    IntegrityFailureAdvice.logArtifactDigestVerificationRecovery(log);
+
+    verify(log).error(contains("If these changes were intentional"));
+    verify(log).error(contains("mvn package"));
+    verify(log).error(contains("-D" + IntegrityFailureAdvice.SKIP_PROPERTY + "=true"));
+    verify(log).error(contains("-D" + IntegrityFailureAdvice.SKIP_PROPERTY_ALT + "=true"));
+  }
+
+  @Test
+  @DisplayName("null log is a no-op")
+  void nullLogIsNoOp() {
+    IntegrityFailureAdvice.logHashVerificationRecovery(null);
+    IntegrityFailureAdvice.logArtifactDigestVerificationRecovery(null);
+  }
+
+  @Test
+  @DisplayName("hash recovery advice does not mention packaging")
+  void hashAdviceDoesNotMentionPackage() {
+    Log log = mock(Log.class);
+
+    IntegrityFailureAdvice.logHashVerificationRecovery(log);
+
+    verify(log, never()).error(contains("mvn package"));
+  }
+}

--- a/src/test/java/com/intsof/ai/build/integrity/IntegrityFailureAdviceTest.java
+++ b/src/test/java/com/intsof/ai/build/integrity/IntegrityFailureAdviceTest.java
@@ -38,6 +38,8 @@ class IntegrityFailureAdviceTest {
     verify(log).error(contains("mvn validate"));
     verify(log).error(contains("-D" + IntegrityFailureAdvice.SKIP_PROPERTY + "=true"));
     verify(log).error(contains("-D" + IntegrityFailureAdvice.SKIP_PROPERTY_ALT + "=true"));
+    // Spacer must be non-empty so backends that drop blank lines still keep the visual gap
+    verify(log).error(" ");
   }
 
   @Test


### PR DESCRIPTION
## Summary

Implements [#42](https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/issues/42): when integrity verification fails, the build log now prints actionable recovery guidance for intentional edits, while still failing the build when `failOnError=true`.

- New `IntegrityFailureAdvice` helper logs a consistent recovery footer
- `HashVerifyMojo` advises `mvn validate` to re-seal hashes and prints exact skip `-D` options
- `ArtifactDigestsVerifyMojo` advises `mvn package` for digests plus the same skip options
- Site troubleshooting docs aligned with the in-log wording
- Version bumped to **0.13.0** (MINOR feature)

## Example failure footer (`verify-hashes`)

```text
------------------------------------------------------------------------
If these changes were intentional, re-seal the project by regenerating hashes:
  mvn validate

To temporarily skip integrity verification for this build:
  -Dai.integrity.skip=true
  (also accepted: -Dskip.ai.integrity=true)
------------------------------------------------------------------------
```

## Test plan

- [x] `mvn test` (Java 21) — all unit tests pass
- [x] New `IntegrityFailureAdviceTest` covers hash and artifact recovery text
- [x] `HashVerifyMojoTest` asserts recovery logs on mismatch / missing file / `failOnError=false`
- [x] `ArtifactDigestsVerifyMojoTest` asserts recovery logs on tampered artifact
- [ ] Reviewer: confirm wording matches Dev/SecOps expectations

Closes #42