### PR TITLE
fix: honor Windows basedir paths in ResumeFrom.matchesProject (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.2] - 2026-07-16
+
+### Fixed
+
+- **`ResumeFrom.matchesProject` Windows basedir paths**: Resume-from selector matching now correctly accepts absolute Windows drive-letter paths and relative basedir paths. Previously the single-colon `groupId:artifactId` heuristic misclassified Windows absolute paths like `C:\…\module-b` (treated as `groupId="C"`) and never reached the basedir comparison, causing `mvn -rf :module` to fail to re-seal on Windows. Path matching now normalizes both absolute and relative forms, checks `endsWith` against the basedir, and restores the basedir-name fallback as an independent match (#46).
+
 ## [0.13.1] - 2026-07-16
 
 ### Fixed
@@ -81,7 +87,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - .gitignore awareness and automatic directory pruning.
 - Machine-readable JSON audit reports for SIEM integration.
 
-[0.13.1]: https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/compare/v0.13.0...HEAD
+[0.13.2]: https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/compare/v0.13.1...HEAD
+[0.13.1]: https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/intersoftdatalabs-in/ai-build-integrity-maven-plugin/compare/v0.11.0...v0.11.1

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>com.intsof</groupId>
     <artifactId>ai-build-integrity-maven-plugin</artifactId>
-    <version>0.13.1</version>
+    <version>0.13.2</version>
     <packaging>maven-plugin</packaging>
 
     <name>AI Build Integrity Maven Plugin</name>

--- a/src/main/java/com/intsof/ai/build/integrity/ResumeFrom.java
+++ b/src/main/java/com/intsof/ai/build/integrity/ResumeFrom.java
@@ -119,11 +119,15 @@ final class ResumeFrom {
 
     // groupId:artifactId (exactly one colon, not starting with colon)
     int colon = trimmed.indexOf(':');
-    if (colon > 0 && trimmed.indexOf(':', colon + 1) < 0) {
+    boolean windowsAbsolutePath =
+        colon == 1
+            && trimmed.length() > 2
+            && (trimmed.charAt(2) == '\\' || trimmed.charAt(2) == '/');
+    if (colon > 0 && trimmed.indexOf(':', colon + 1) < 0 && !windowsAbsolutePath) {
       String g = trimmed.substring(0, colon);
       String a = trimmed.substring(colon + 1);
-      if (!a.isEmpty()) {
-        return g.equals(groupId) && a.equals(artifactId);
+      if (!a.isEmpty() && g.equals(groupId) && a.equals(artifactId)) {
+        return true;
       }
     }
 
@@ -137,16 +141,17 @@ final class ResumeFrom {
     if (basedir != null) {
       Path projectPath = basedir.toPath().toAbsolutePath().normalize();
       try {
-        Path selectorPath = java.nio.file.Paths.get(trimmed).toAbsolutePath().normalize();
-        if (projectPath.equals(selectorPath)) {
+        Path relativeSelectorPath = java.nio.file.Paths.get(trimmed).normalize();
+        Path absoluteSelectorPath = relativeSelectorPath.toAbsolutePath().normalize();
+        if (projectPath.equals(absoluteSelectorPath)
+            || projectPath.endsWith(relativeSelectorPath)) {
           return true;
         }
       } catch (Exception ignored) {
         // not a usable path selector
       }
       // also accept basedir name or suffix path segment match
-      if (trimmed.equals(basedir.getName())
-          || projectPath.endsWith(java.nio.file.Paths.get(trimmed))) {
+      if (trimmed.equals(basedir.getName())) {
         return true;
       }
     }


### PR DESCRIPTION
## Summary

Fixes `ResumeFrom.matchesProject` so it correctly handles Windows absolute basedir paths and relative basedir selectors. Closes #46.

## Root cause

The selector classifier in `src/main/java/com/intsof/ai/build/integrity/ResumeFrom.java:120-128` treated any string with exactly one `:` as `groupId:artifactId`, so a Windows path like `C:\Projects\demo\module-b` was parsed as `groupId="C"`, never reaching the basedir comparison. The suffix `endsWith` check required an absolute selector, and the basedir-name / suffix fallbacks were combined with `||`, so a relative basedir-name selector could fall through to `false`. `ResumeFromTest.MatchesProjectTests.matchesBasedirPath` failed on Windows with `expected: <true> but was: <false>`.

## Fix

- Skip the `groupId:artifactId` branch when the selector is a Windows drive-letter path (`X:\` or `X:/`).
- Normalize the selector as both relative and absolute paths and compare to the normalized project path with `equals` and `endsWith`.
- Restore the basedir-name fallback as an independent match.

## Validation

- `mvn -Dtest=ResumeFromTest test`: 8/8 pass (was 7/8).
- `mvn verify`: 202/202 tests pass, Spotless + Javadoc clean.

## Versioning

Bumps to `0.13.2` (PATCH bug fix). `CHANGELOG.md` documents the fix and links issue #46.

## Issue

Closes #46.