### PR TITLE
test: cover OS-native basedir selector forms in ResumeFrom.matchesProject

### DIFF
--- a/src/test/java/com/intsof/ai/build/integrity/ResumeFromTest.java
+++ b/src/test/java/com/intsof/ai/build/integrity/ResumeFromTest.java
@@ -103,6 +103,36 @@ class ResumeFromTest {
       assertTrue(ResumeFrom.matchesProject(basedir.getAbsolutePath(), project));
       assertTrue(ResumeFrom.matchesProject(basedir.getName(), project));
     }
+
+    @Test
+    @DisplayName("matches project basedir in OS-native forms")
+    void matchesBasedirInOsNativeForms() {
+      File basedir = tempDir.toFile();
+      when(project.getArtifactId()).thenReturn("module-b");
+      when(project.getGroupId()).thenReturn("com.example");
+      when(project.getBasedir()).thenReturn(basedir);
+
+      String absolute = basedir.getAbsolutePath();
+      String normalizedAbsolute = basedir.toPath().toAbsolutePath().normalize().toString();
+      String name = basedir.getName();
+      String relative = basedir.getParentFile().toPath().relativize(basedir.toPath()).toString();
+
+      assertTrue(
+          ResumeFrom.matchesProject(absolute, project), "absolute OS-native path: " + absolute);
+      assertTrue(
+          ResumeFrom.matchesProject(normalizedAbsolute, project),
+          "normalized absolute path: " + normalizedAbsolute);
+      assertTrue(
+          ResumeFrom.matchesProject(name, project), "basedir name (relative segment): " + name);
+      assertTrue(
+          ResumeFrom.matchesProject(relative, project), "relative path from parent: " + relative);
+      assertFalse(
+          ResumeFrom.matchesProject(basedir.getAbsolutePath() + File.separator + "child", project),
+          "unrelated absolute subpath must not match");
+      assertFalse(
+          ResumeFrom.matchesProject(name + "-other", project),
+          "near-miss bare name must not match");
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Summary

Adds `matchesBasedirInOsNativeForms` to `ResumeFromTest.MatchesProjectTests` to lock in the Windows basedir-path fix from #47 (now merged) with selectors built via OS-native APIs (`File.getAbsolutePath`, `Path.normalize`, `File.getParentFile.relativize`, `File.separator`). The same assertions hold on Linux and Windows without any platform branching.

## What's covered

Positive selectors that must match:
- absolute OS-native path (`/tmp/junit…` on Linux, `C:\Users\…\junit…` on Windows)
- normalized absolute path
- bare basedir name (single relative segment)
- relative multi-segment path from the basedir's parent

Negative selectors that must not match:
- unrelated absolute subpath under the basedir
- near-miss bare name (`<name>-other`)

## Validation

- `mvn -Dtest=ResumeFromTest test`: 9/9 pass (was 8/8).
- `mvn clean install`: 203/203 tests pass, Spotless + Javadoc clean, JAR installed.

## Related

- #46 - original bug report
- #47 - Windows basedir path fix (merged)