### PR TITLE
fix: include recovery advice in Maven goal-failure summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.3] - 2026-07-23
+
+### Fixed
+
+- **Recovery advice in Maven goal-failure summary**: When `verify-hashes` or `verify-artifact-digests` fails with `failOnError=true`, re-seal and skip guidance (`mvn validate` / `mvn package`, `-Dai.integrity.skip=true`, `-Dskip.ai.integrity=true`) is now included in the `MojoExecutionException` message. Maven's final `Failed to execute goal` summary therefore shows how to correct or temporarily skip the integrity violation, not only the short "N file(s) have been modified" line. Plugin `log.error` recovery banners are unchanged (#49).
+
 ## [0.13.2] - 2026-07-16
 
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>com.intsof</groupId>
     <artifactId>ai-build-integrity-maven-plugin</artifactId>
-    <version>0.13.2</version>
+    <version>0.13.3</version>
     <packaging>maven-plugin</packaging>
 
     <name>AI Build Integrity Maven Plugin</name>

--- a/src/main/java/com/intsof/ai/build/integrity/ArtifactDigestsVerifyMojo.java
+++ b/src/main/java/com/intsof/ai/build/integrity/ArtifactDigestsVerifyMojo.java
@@ -230,7 +230,10 @@ public class ArtifactDigestsVerifyMojo extends AbstractMojo {
           "Artifact digest verification FAILED: " + failed + " failed, " + missing + " missing.";
       IntegrityFailureAdvice.logArtifactDigestVerificationRecovery(log);
       if (failOnError) {
-        throw new MojoExecutionException(msg);
+        // Include recovery advice in the exception so Maven's final "Failed to execute goal"
+        // summary shows skip/re-seal guidance (log lines alone are easy to miss in long builds).
+        throw new MojoExecutionException(
+            msg + "\n" + IntegrityFailureAdvice.formatArtifactDigestVerificationRecovery());
       } else {
         log.error("------------------------------------------------------------------------");
         log.error("AI BUILD INTEGRITY WARNING: " + msg);

--- a/src/main/java/com/intsof/ai/build/integrity/HashVerifyMojo.java
+++ b/src/main/java/com/intsof/ai/build/integrity/HashVerifyMojo.java
@@ -471,7 +471,10 @@ public class HashVerifyMojo extends AbstractMojo {
           "Hash verification FAILED: " + failed + " file(s) have been modified or tampered with!";
       IntegrityFailureAdvice.logHashVerificationRecovery(getLog());
       if (failOnError) {
-        throw new MojoExecutionException(msg);
+        // Include recovery advice in the exception so Maven's final "Failed to execute goal"
+        // summary shows skip/re-seal guidance (log lines alone are easy to miss in long builds).
+        throw new MojoExecutionException(
+            msg + "\n" + IntegrityFailureAdvice.formatHashVerificationRecovery());
       } else {
         getLog().error("------------------------------------------------------------------------");
         getLog().error("AI BUILD INTEGRITY WARNING: " + msg);

--- a/src/main/java/com/intsof/ai/build/integrity/IntegrityFailureAdvice.java
+++ b/src/main/java/com/intsof/ai/build/integrity/IntegrityFailureAdvice.java
@@ -22,6 +22,11 @@ import org.apache.maven.plugin.logging.Log;
  *
  * <p>Verification still fails the build when {@code failOnError} is true; this class only improves
  * the developer-facing failure UX so intentional edits are easy to re-seal or temporarily skip.
+ *
+ * <p>Recovery text is both logged ({@link #logHashVerificationRecovery(Log)}) and included in the
+ * {@code MojoExecutionException} message via {@link #formatHashVerificationRecovery()} so it
+ * appears in Maven's final {@code Failed to execute goal} summary — the block users typically read
+ * after a long multi-module build.
  */
 public final class IntegrityFailureAdvice {
 
@@ -40,6 +45,19 @@ public final class IntegrityFailureAdvice {
    */
   private static final String SPACER = " ";
 
+  private static final String HASH_INTENTIONAL_LEAD =
+      "If these changes were intentional, re-seal the project by regenerating hashes:";
+
+  private static final String HASH_REGENERATE_COMMAND = "  mvn validate";
+
+  private static final String ARTIFACT_INTENTIONAL_LEAD =
+      "If these changes were intentional, re-generate artifact digests (e.g. re-run packaging):";
+
+  private static final String ARTIFACT_REGENERATE_COMMAND = "  mvn package";
+
+  private static final String SKIP_LEAD =
+      "To temporarily skip integrity verification for this build:";
+
   private IntegrityFailureAdvice() {}
 
   /**
@@ -48,11 +66,17 @@ public final class IntegrityFailureAdvice {
    * @param log the Maven plugin logger; no-op when {@code null}
    */
   public static void logHashVerificationRecovery(Log log) {
-    logRecovery(
-        log,
-        "If these changes were intentional, re-seal the project by regenerating hashes:",
-        "  mvn validate",
-        "To temporarily skip integrity verification for this build:");
+    logRecovery(log, HASH_INTENTIONAL_LEAD, HASH_REGENERATE_COMMAND, SKIP_LEAD);
+  }
+
+  /**
+   * Formats recovery advice for AI resource hash verification failures for inclusion in a {@code
+   * MojoExecutionException} message.
+   *
+   * @return multi-line recovery text (no trailing newline)
+   */
+  public static String formatHashVerificationRecovery() {
+    return formatRecovery(HASH_INTENTIONAL_LEAD, HASH_REGENERATE_COMMAND, SKIP_LEAD);
   }
 
   /**
@@ -62,11 +86,17 @@ public final class IntegrityFailureAdvice {
    * @param log the Maven plugin logger; no-op when {@code null}
    */
   public static void logArtifactDigestVerificationRecovery(Log log) {
-    logRecovery(
-        log,
-        "If these changes were intentional, re-generate artifact digests (e.g. re-run packaging):",
-        "  mvn package",
-        "To temporarily skip integrity verification for this build:");
+    logRecovery(log, ARTIFACT_INTENTIONAL_LEAD, ARTIFACT_REGENERATE_COMMAND, SKIP_LEAD);
+  }
+
+  /**
+   * Formats recovery advice for artifact digest verification failures for inclusion in a {@code
+   * MojoExecutionException} message.
+   *
+   * @return multi-line recovery text (no trailing newline)
+   */
+  public static String formatArtifactDigestVerificationRecovery() {
+    return formatRecovery(ARTIFACT_INTENTIONAL_LEAD, ARTIFACT_REGENERATE_COMMAND, SKIP_LEAD);
   }
 
   /**
@@ -90,5 +120,30 @@ public final class IntegrityFailureAdvice {
     log.error("  -D" + SKIP_PROPERTY + "=true");
     log.error("  (also accepted: -D" + SKIP_PROPERTY_ALT + "=true)");
     log.error(BANNER);
+  }
+
+  /**
+   * Formats the same recovery content used by {@link #logRecovery} as a single multi-line string
+   * suitable for exception messages (no banner lines).
+   *
+   * @param intentionalLead lead sentence for intentional edits
+   * @param regenerateCommand example Maven command to re-seal (already indented)
+   * @param skipLead lead sentence before skip properties
+   * @return multi-line recovery text
+   */
+  static String formatRecovery(String intentionalLead, String regenerateCommand, String skipLead) {
+    return intentionalLead
+        + "\n"
+        + regenerateCommand
+        + "\n"
+        + skipLead
+        + "\n"
+        + "  -D"
+        + SKIP_PROPERTY
+        + "=true"
+        + "\n"
+        + "  (also accepted: -D"
+        + SKIP_PROPERTY_ALT
+        + "=true)";
   }
 }

--- a/src/main/java/com/intsof/ai/build/integrity/IntegrityFailureAdvice.java
+++ b/src/main/java/com/intsof/ai/build/integrity/IntegrityFailureAdvice.java
@@ -124,7 +124,8 @@ public final class IntegrityFailureAdvice {
 
   /**
    * Formats the same recovery content used by {@link #logRecovery} as a single multi-line string
-   * suitable for exception messages (no banner lines).
+   * suitable for exception messages (no banner lines). Includes the same non-empty {@link #SPACER}
+   * between regenerate and skip blocks so the visual gap matches the log output.
    *
    * @param intentionalLead lead sentence for intentional edits
    * @param regenerateCommand example Maven command to re-seal (already indented)
@@ -135,6 +136,8 @@ public final class IntegrityFailureAdvice {
     return intentionalLead
         + "\n"
         + regenerateCommand
+        + "\n"
+        + SPACER
         + "\n"
         + skipLead
         + "\n"

--- a/src/test/java/com/intsof/ai/build/integrity/ArtifactDigestsVerifyMojoTest.java
+++ b/src/test/java/com/intsof/ai/build/integrity/ArtifactDigestsVerifyMojoTest.java
@@ -90,8 +90,12 @@ class ArtifactDigestsVerifyMojoTest {
       // Tamper with the artifact
       Files.write(jarFile, "tampered content".getBytes(StandardCharsets.UTF_8));
 
-      // When/Then - should throw and log recovery advice
-      assertThrows(MojoExecutionException.class, () -> mojo.execute());
+      // When/Then - should throw and include recovery advice in exception + logs
+      MojoExecutionException ex = assertThrows(MojoExecutionException.class, () -> mojo.execute());
+      assertTrue(ex.getMessage().contains("FAILED"));
+      assertTrue(ex.getMessage().contains("mvn package"));
+      assertTrue(ex.getMessage().contains("-Dai.integrity.skip=true"));
+      assertTrue(ex.getMessage().contains("-Dskip.ai.integrity=true"));
       verify(log).error(contains("If these changes were intentional"));
       verify(log).error(contains("mvn package"));
       verify(log).error(contains("-Dai.integrity.skip=true"));

--- a/src/test/java/com/intsof/ai/build/integrity/HashVerifyMojoTest.java
+++ b/src/test/java/com/intsof/ai/build/integrity/HashVerifyMojoTest.java
@@ -94,8 +94,10 @@ class HashVerifyMojoTest {
       MojoExecutionException ex = assertThrows(MojoExecutionException.class, () -> mojo.execute());
       assertTrue(ex.getMessage().contains("FAILED"));
       assertTrue(ex.getMessage().contains("tampered"));
-      // Exception message stays short; recovery guidance is logged separately
-      assertFalse(ex.getMessage().contains("mvn validate"));
+      // Recovery guidance must be in the exception so Maven's final goal-failure summary shows it
+      assertTrue(ex.getMessage().contains("mvn validate"));
+      assertTrue(ex.getMessage().contains("-Dai.integrity.skip=true"));
+      assertTrue(ex.getMessage().contains("-Dskip.ai.integrity=true"));
       verify(log).error(contains("If these changes were intentional"));
       verify(log).error(contains("mvn validate"));
       verify(log).error(contains("-Dai.integrity.skip=true"));
@@ -113,6 +115,8 @@ class HashVerifyMojoTest {
       // When/Then
       MojoExecutionException ex = assertThrows(MojoExecutionException.class, () -> mojo.execute());
       assertTrue(ex.getMessage().contains("FAILED"));
+      assertTrue(ex.getMessage().contains("mvn validate"));
+      assertTrue(ex.getMessage().contains("-Dai.integrity.skip=true"));
       verify(log).error(contains("If these changes were intentional"));
       verify(log).error(contains("mvn validate"));
     }

--- a/src/test/java/com/intsof/ai/build/integrity/IntegrityFailureAdviceTest.java
+++ b/src/test/java/com/intsof/ai/build/integrity/IntegrityFailureAdviceTest.java
@@ -68,6 +68,10 @@ class IntegrityFailureAdviceTest {
     assertTrue(text.contains("-D" + IntegrityFailureAdvice.SKIP_PROPERTY + "=true"));
     assertTrue(text.contains("-D" + IntegrityFailureAdvice.SKIP_PROPERTY_ALT + "=true"));
     assertFalse(text.contains("mvn package"));
+    // Spacer line must match logRecovery (non-empty) between regenerate and skip blocks
+    assertTrue(
+        text.contains("mvn validate\n \nTo temporarily skip"),
+        "formatRecovery must include SPACER between regenerate command and skip lead");
   }
 
   @Test
@@ -80,6 +84,9 @@ class IntegrityFailureAdviceTest {
     assertTrue(text.contains("-D" + IntegrityFailureAdvice.SKIP_PROPERTY + "=true"));
     assertTrue(text.contains("-D" + IntegrityFailureAdvice.SKIP_PROPERTY_ALT + "=true"));
     assertFalse(text.contains("mvn validate"));
+    assertTrue(
+        text.contains("mvn package\n \nTo temporarily skip"),
+        "formatRecovery must include SPACER between regenerate command and skip lead");
   }
 
   @Test

--- a/src/test/java/com/intsof/ai/build/integrity/IntegrityFailureAdviceTest.java
+++ b/src/test/java/com/intsof/ai/build/integrity/IntegrityFailureAdviceTest.java
@@ -15,6 +15,8 @@
  */
 package com.intsof.ai.build.integrity;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -54,6 +56,30 @@ class IntegrityFailureAdviceTest {
     verify(log).error(contains("mvn package"));
     verify(log).error(contains("-D" + IntegrityFailureAdvice.SKIP_PROPERTY + "=true"));
     verify(log).error(contains("-D" + IntegrityFailureAdvice.SKIP_PROPERTY_ALT + "=true"));
+  }
+
+  @Test
+  @DisplayName("formatHashVerificationRecovery includes validate and skip -D options")
+  void formatHashVerificationRecoveryEmitsExpectedGuidance() {
+    String text = IntegrityFailureAdvice.formatHashVerificationRecovery();
+
+    assertTrue(text.contains("If these changes were intentional"));
+    assertTrue(text.contains("mvn validate"));
+    assertTrue(text.contains("-D" + IntegrityFailureAdvice.SKIP_PROPERTY + "=true"));
+    assertTrue(text.contains("-D" + IntegrityFailureAdvice.SKIP_PROPERTY_ALT + "=true"));
+    assertFalse(text.contains("mvn package"));
+  }
+
+  @Test
+  @DisplayName("formatArtifactDigestVerificationRecovery includes package and skip -D options")
+  void formatArtifactDigestVerificationRecoveryEmitsExpectedGuidance() {
+    String text = IntegrityFailureAdvice.formatArtifactDigestVerificationRecovery();
+
+    assertTrue(text.contains("If these changes were intentional"));
+    assertTrue(text.contains("mvn package"));
+    assertTrue(text.contains("-D" + IntegrityFailureAdvice.SKIP_PROPERTY + "=true"));
+    assertTrue(text.contains("-D" + IntegrityFailureAdvice.SKIP_PROPERTY_ALT + "=true"));
+    assertFalse(text.contains("mvn validate"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Fixes #49: when `verify-hashes` / `verify-artifact-digests` fails with `failOnError=true`, re-seal and skip guidance is included in the `MojoExecutionException` message so Maven's final `Failed to execute goal` summary shows how to recover.
- Adds `IntegrityFailureAdvice.formatHashVerificationRecovery()` and `formatArtifactDigestVerificationRecovery()`; keeps existing multi-line `log.error` banners.
- Bumps version to **0.13.3** and updates CHANGELOG.

## Problem

Users only saw:

```
Hash verification FAILED: 1 file(s) have been modified or tampered with!
```

in Maven's end-of-build error summary. Recovery advice added in 0.13.0 (#42) was logged via `log.error` only, which is easy to miss after a long multi-module build or when CI tails only the final summary.

## After this fix

The exception message includes:

- Intentional re-seal: `mvn validate` (hashes) / `mvn package` (artifact digests)
- Temporary skip: `-Dai.integrity.skip=true` / `-Dskip.ai.integrity=true`

## Test plan

- [x] Unit tests assert exception messages contain recovery guidance for hash and artifact digest failures
- [x] `IntegrityFailureAdvice` format methods covered
- [x] `mvn test` (Java 21) passes including Spotless
- [ ] After merge/release, reproduce intentional hash mismatch and confirm Maven's final goal-failure block shows skip/re-seal lines

> Co-Authored by Grok Build using grok-4.5 with agent main.